### PR TITLE
getDOMNode() has been deprecated. Use React.findDOMNode() instead.

### DIFF
--- a/client/src/component/toolbar/ToolbarTop.js
+++ b/client/src/component/toolbar/ToolbarTop.js
@@ -177,7 +177,7 @@ var ToolbarTop = React.createClass({
     _handleCurrentPageNameChange: function(e){
         e.stopPropagation();
         e.preventDefault();
-        var inputValue = this.refs.currentPageNameInput.getDOMNode().value;
+        var inputValue = React.findDOMNode(this.refs.currentPageNameInput).value;
         if(!inputValue || inputValue.length == 0){
             this._backupInputValue = this.state.currentPageName;
             ToolbarTopActions.currentPageNameChange(inputValue);


### PR DESCRIPTION
https://facebook.github.io/react/blog/2015/03/10/react-v0.13.html
https://facebook.github.io/react/docs/component-api.html#getdomnode
https://facebook.github.io/react/blog/2015/07/03/react-v0.14-beta-1.html#dom-node-refs